### PR TITLE
Tableau Embed Bug Fix

### DIFF
--- a/content/blog/mdx-test/mdx-test.mdx
+++ b/content/blog/mdx-test/mdx-test.mdx
@@ -4,9 +4,16 @@ date: "2021-04-21"
 description: "This is the first MDX Post."
 ---
 
-# This is an MDX Post
+Far far away, behind the word mountains, far from the countries Vokalia and
+Consonantia, there live the blind texts. Separated they live in Bookmarksgrove
+right at the coast of the Semantics, a large language ocean. A small river named
+Duden flows by their place and supplies it with the necessary regelialia.
 
-Add your data to this post.
+When she reached the first hills of the **Italic Mountains**, she had a last
+view back on the skyline of her hometown _Bookmarksgrove_, the headline of
+[Alphabet Village](http://google.com) and the subline of her own road, the Line
+Lane. Pityful a rhetoric question ran over her cheek, then she continued her
+way. On her way she met a copy.
 
 <br/>
 
@@ -21,6 +28,20 @@ Add your data to this post.
   }
 />
 
+<br/>
+
+### On deer horse aboard tritely yikes and much
+
+The Big Oxmox advised her not to do so, because there were thousands of bad
+Commas, wild Question Marks and devious Semikoli, but the Little Blind Text
+didn’t listen. She packed her seven versalia, put her initial into the belt and
+made herself on the way.
+
+- This however showed weasel
+- Well uncritical so misled
+  - this is very interesting
+- Goodness much until that fluid owl
+
 <Tableau
   viz="https://public.tableau.com/views/FormStackExamples/SurveyResults"
   options={{
@@ -28,3 +49,32 @@ Add your data to this post.
     height: 1250
   }}
 />
+
+### Overlaid the jeepers uselessly much excluding
+
+But nothing the copy said could convince her and so it didn’t take long until a
+few insidious Copy Writers ambushed her, made her drunk with
+[Longe and Parole](http://google.com) and dragged her into their agency, where
+they abused her for their projects again and again. And if she hasn’t been
+rewritten, then they are still using her.
+
+> Far far away, behind the word mountains, far from the countries Vokalia and
+> Consonantia, there live the blind texts. Separated they live in Bookmarksgrove
+> right at the coast of the Semantics, a large language ocean.
+
+You can also write code blocks here!
+
+```js
+const saltyDuckEgg = "chinese preserved food product"
+```
+
+| Number | Title                                    | Year |
+| :----- | :--------------------------------------- | ---: |
+| 1      | Harry Potter and the Philosopher’s Stone | 2001 |
+| 2      | Harry Potter and the Chamber of Secrets  | 2002 |
+| 3      | Harry Potter and the Prisoner of Azkaban | 2004 |
+
+It is a paradisematic country, in which roasted parts of sentences fly into your
+mouth. Even the all-powerful Pointing has no control about the blind texts it is
+an almost unorthographic life One day however a small line of blind text by the
+name of Lorem Ipsum decided to leave for the far World of Grammar.

--- a/src/components/layout/layout.js
+++ b/src/components/layout/layout.js
@@ -1,5 +1,4 @@
 import React from "react"
-import Helmet from "react-helmet"
 import { MDXProvider } from "@mdx-js/react"
 import Navbar from "../navbar/navbar"
 import Footer from "../footer/footer"
@@ -8,15 +7,11 @@ import Callout from "../callout/callout"
 import Tableau from "../tableau/tableau"
 
 const shortcodes = { Callout, Tableau };
-const tableauApi = "https://public.tableau.com/javascripts/api/tableau-2.7.0.min.js";
 
 export default function Layout({ children }) {
   return (
     <>
       <Seo />
-      <Helmet>
-        <script type="text/javascript" src={tableauApi} />
-      </Helmet>
       <div className="site">
         <Navbar />
         <main className="main">

--- a/src/components/tableau/tableau.js
+++ b/src/components/tableau/tableau.js
@@ -1,12 +1,34 @@
-import React, { useEffect } from "react"
+import React, { useState, useEffect } from "react"
 import "./tableau.css"
 
-export default function TableauApi(props) {
+export default function Tableau(props) {
+
+  const [loaded, setLoaded] = useState(false);
+  const styleObj = {
+    height: props.options.height,
+    width: "100%"
+  };
 
   useEffect(() => {
+    loadTableau()
+  },[]);
+
+  useEffect(() => {
+    if (!loaded) return
     // Wait until the component mounts or updates to run initViz()
-    initViz();
-  });
+    initViz()
+  }, [loaded]);
+
+  const loadTableau = () => {
+    if (document.getElementById("tableauAPI")) return initViz()
+
+    const tableauAPI = document.createElement('script');
+    tableauAPI.id = "tableauAPI"
+    tableauAPI.type = "text/javascript";
+    tableauAPI.src = "https://public.tableau.com/javascripts/api/tableau-2.7.0.min.js";
+    tableauAPI.addEventListener('load', () => setLoaded(true))
+    document.body.appendChild(tableauAPI)
+  };
 
   const initViz = () => {
     const vizContainer = document.getElementById("vizContainer");
@@ -19,12 +41,7 @@ export default function TableauApi(props) {
     const vizObj = new tableau.Viz(vizContainer, props.viz, props.options);
   };
 
-  const styleObj = {
-    height: props.options.height,
-    width: "100%"
-  }
-
   return (
-    <div id="vizContainer" className="container" style={styleObj} />
+    <div id="vizContainer" className="container" style={styleObj}/>
   )
 }


### PR DESCRIPTION
Fixes #38 

Adding the <script> by way of react-helmet was interfering with onLoad events triggering before this component was rendered, therefore either wanting to run the embed script before the external Tableau API script was ready or not being able to run useState later allowing for useEffect to run after the DOM was rendered.

By instead adding the <script> towards the end of the body, the onLoad synthetic event runs as expected and is able to run useState to initialize the viz object once the Tableau API externals script was available.

Visualizations will now load without errors during normal navigation, when reloading, etc. This also checks to make sure that a <script> doesn't already exist beforehand and avoids loading duplicates.

A future PR may add the ability to use Tableau API scripts from multiple servers.